### PR TITLE
Routes caching

### DIFF
--- a/core.sh
+++ b/core.sh
@@ -485,9 +485,7 @@ writeHttpResponse() {
 }
 
 findRoutes() {
-  local SIZE
-  SIZE=$(stat -c "%s" $ROUTES_CACHE)
-  if [[ $SIZE -eq 0 ]]; then
+  if [[ -z $ROUTES_CACHE ]] || [[ $(stat -c "%s" $ROUTES_CACHE) -eq 0 ]]; then
     cd pages
     find . -type f,l -iname '*.sh' | sed 's@^\./@@' | tee $ROUTES_CACHE
   else

--- a/core.sh
+++ b/core.sh
@@ -485,11 +485,14 @@ writeHttpResponse() {
 }
 
 findRoutes() {
-  cd pages
-  for i in $(find . -type f,l -iname '*.sh' \
-    | sed 's@^\./@@'); do
-    echo $i;
-  done
+  local SIZE
+  SIZE=$(stat -c "%s" $ROUTES_CACHE)
+  if [[ $SIZE -eq 0 ]]; then
+    cd pages
+    find . -type f,l -iname '*.sh' | sed 's@^\./@@' | tee $ROUTES_CACHE
+  else
+    cat $ROUTES_CACHE
+  fi
 }
 
 findPredefinedRoutes() {

--- a/start.sh
+++ b/start.sh
@@ -10,6 +10,8 @@ if [[ "${DEV:-true}" == "true" ]] && [[ ! -z "$TAILWIND" ]]; then
    PID=$!
 fi
 
+export ROUTES_CACHE=$(mktemp)
+
 # remove any old subscriptions; they are no longer valid
 rm -rf pubsub
 

--- a/start.sh
+++ b/start.sh
@@ -10,7 +10,9 @@ if [[ "${DEV:-true}" == "true" ]] && [[ ! -z "$TAILWIND" ]]; then
    PID=$!
 fi
 
-export ROUTES_CACHE=$(mktemp)
+if [[ "${DEV:-true}" != "true" ]]; then
+  export ROUTES_CACHE=$(mktemp)
+fi
 
 # remove any old subscriptions; they are no longer valid
 rm -rf pubsub


### PR DESCRIPTION
It has been done. Usually, `/tmp` is a ramfs on modern-ish Linuxes. So, this should be fast. Caching is disabled by default.

Also removed a weird `for i` loop that didn't seem to do anything.